### PR TITLE
refactor: removes ABI encoding for input params

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -9,9 +9,9 @@ export const ERROR_MESSAGES: Record<ErrorCodes, string> = {
   [ErrorCodes.VerificationRejected]: 'User rejected verification request in Worldcoin app.',
   [ErrorCodes.AlreadySigned]: 'User has previously signed and submitted proof for this action.',
   [ErrorCodes.InvalidActionID]:
-    "The provided external nullifier is not valid. Make sure it's a valid string. Review the docs for details.",
+    "The provided action ID is not valid. Make sure it's a valid string. Review the docs for details.",
   [ErrorCodes.InvalidSignal]:
-    "The provided proof signal is not valid. Make sure it's a valid string or address. Review the docs for details.",
+    "The provided signal is not valid. Make sure it's a valid string or address. Review the docs for details.",
   [ErrorCodes.UnexpectedResponse]: 'Received an unexpected response from WLD app. Please try again.',
   [ErrorCodes.GenericError]: 'An unhandled exception ocurred. Please try again.',
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -9,9 +9,9 @@ export const ERROR_MESSAGES: Record<ErrorCodes, string> = {
   [ErrorCodes.VerificationRejected]: 'User rejected verification request in Worldcoin app.',
   [ErrorCodes.AlreadySigned]: 'User has previously signed and submitted proof for this action.',
   [ErrorCodes.InvalidExternalNullifier]:
-    "The provided external nullifier is not valid. Make sure it's a valid ABI-encoded value. Review the docs for details.",
+    "The provided external nullifier is not valid. Make sure it's a valid string. Review the docs for details.",
   [ErrorCodes.InvalidProofSignal]:
-    "The provided proof signal is not valid. Make sure it's a valid ABI-encoded value. Review the docs for details.",
+    "The provided proof signal is not valid. Make sure it's a valid string or address. Review the docs for details.",
   [ErrorCodes.UnexpectedResponse]: 'Received an unexpected response from WLD app. Please try again.',
   [ErrorCodes.GenericError]: 'An unhandled exception ocurred. Please try again.',
 }

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@
     <script>
       worldID.init('world-id-container', {
         enableTelemetry: true,
-        actionId: '@test/candy-drop-2022',
+        actionId: '0x330C8452C879506f313D1565702560435b0fee4C',
         signal: '0x0000000000000000000000000000000000000000',
         appName: 'candyApp',
         signalDescription: 'Receive initial airdrop April 2022',

--- a/src/index.html
+++ b/src/index.html
@@ -56,9 +56,8 @@
     <script>
       worldID.init('world-id-container', {
         enableTelemetry: true,
-        externalNullifier:
-          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000f63616e64792d64726f702d323032320000000000000000000000000000000000',
-        proofSignal: '0x0000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
+        externalNullifier: '@test/candy-drop-2022',
+        proofSignal: '0x0000000000000000000000000000000000000000',
         appName: 'candyApp',
         signalDescription: 'Receive initial airdrop April 2022',
       })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,8 +4,8 @@ import { testUtilsPlugin } from 'kea-test-utils'
 import { worldLogic } from 'worldLogic'
 import { init, update, enable, isInitialized, isEnabled } from '.'
 
-const SAMPLE_ACTION_ID = '@worldcoin/testAirdrop'
-const SAMPLE_SIGNAL = '0x0000000000000000000000000000000000000000'
+const SAMPLE_ACTION_ID = '0x330C8452C879506f313D1565702560435b0fee4C' // smart contract's address
+const SAMPLE_SIGNAL = '0x0000000000000000000000000000000000000000' // usually end user's wallet address
 
 beforeEach(() => {
   resetContext({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,7 +4,8 @@ import { testUtilsPlugin } from 'kea-test-utils'
 import { worldLogic } from 'worldLogic'
 import { init, update, enable, isInitialized, isEnabled } from '.'
 
-const VALID_ABI = '0x0000000000000000000000000000000000000000000000000000000000000000'
+const SAMPLE_EXTERNAL_NULLIFIER = '@worldcoin/testAirdrop'
+const SAMPLE_SIGNAL = '0x0000000000000000000000000000000000000000'
 
 beforeEach(() => {
   resetContext({
@@ -25,7 +26,7 @@ beforeAll(() => {
 
 describe('initialization', () => {
   it('can be initialized', () => {
-    init('wld-container-test', { externalNullifier: VALID_ABI, proofSignal: VALID_ABI })
+    init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER, proofSignal: SAMPLE_SIGNAL })
 
     const element = queryAllByTestId(document.body, 'world-id-box')[0]
 
@@ -45,11 +46,13 @@ describe('initialization', () => {
   })
 
   it('cannot be initialized twice', () => {
-    expect(() => init('wld-container-test', { externalNullifier: VALID_ABI, proofSignal: VALID_ABI })).not.toThrow()
+    expect(() =>
+      init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER, proofSignal: SAMPLE_SIGNAL })
+    ).not.toThrow()
 
-    expect(() => init('wld-container-test', { externalNullifier: VALID_ABI, proofSignal: VALID_ABI })).toThrow(
-      'World ID is already initialized. To update properties, please use `worldID.update` instead.'
-    )
+    expect(() =>
+      init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER, proofSignal: SAMPLE_SIGNAL })
+    ).toThrow('World ID is already initialized. To update properties, please use `worldID.update` instead.')
   })
 })
 
@@ -61,7 +64,7 @@ describe('parameter validation', () => {
   })
 
   it('validates externalNullifier is non-empty when updating', () => {
-    init('wld-container-test', { externalNullifier: VALID_ABI })
+    init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER })
 
     expect(() => update({ externalNullifier: '' })).toThrow('The `externalNullifier` parameter is always required.')
   })
@@ -77,7 +80,7 @@ describe('parameter validation', () => {
   })
 
   it('can be initialized with empty `proofSignal`', () => {
-    expect(() => init('wld-container-test', { externalNullifier: VALID_ABI })).not.toThrow()
+    expect(() => init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER })).not.toThrow()
 
     const element = queryAllByTestId(document.body, 'world-id-box')[0]
 
@@ -91,37 +94,25 @@ describe('parameter validation', () => {
     expect(elementStyle.cursor).toBe('not-allowed')
   })
 
-  it('validates `proofSignal` if present', () => {
-    expect(() => init('wld-container-test', { externalNullifier: VALID_ABI, proofSignal: 'invalid' })).toThrow(
-      'The `proofSignal` you provided does not look valid. This parameter should be an ABI-encoded string.'
-    )
-  })
-
-  it('validates `proofSignal` on update', () => {
-    init('wld-container-test', { externalNullifier: VALID_ABI })
-
-    expect(() => update({ proofSignal: '0xinvalid' })).toThrow(
-      'The `proofSignal` you provided does not look valid. This parameter should be an ABI-encoded string.'
-    )
-  })
-
   it('throws error if incorrect element type is passed', () => {
     // @ts-expect-error testing invalid parameters passed, we want to bypass TS for this
-    expect(() => init(123, { externalNullifier: VALID_ABI })).toThrow(
+    expect(() => init(123, { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER })).toThrow(
       'The passed element parameter does not look like a valid HTML element.'
     )
   })
 
   it('throws error if element cannot be found on DOM', () => {
-    expect(() => init('i_dont_exist', { externalNullifier: VALID_ABI })).toThrow(
+    expect(() => init('i_dont_exist', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER })).toThrow(
       'Element to mount World ID not found. Please make sure the element is valid.'
     )
   })
 })
 
 describe('activation', () => {
-  it('can be activated', () => {
-    expect(() => init('wld-container-test', { externalNullifier: VALID_ABI, proofSignal: VALID_ABI })).not.toThrow()
+  it('can be enabled', () => {
+    expect(() =>
+      init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER, proofSignal: SAMPLE_SIGNAL })
+    ).not.toThrow()
 
     const element = queryAllByTestId(document.body, 'world-id-box')[0]
 
@@ -145,7 +136,7 @@ describe('activation', () => {
   })
 
   it('cannot be activated if `proofSignal` is not present', () => {
-    expect(() => init('wld-container-test', { externalNullifier: VALID_ABI })).not.toThrow()
+    expect(() => init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER })).not.toThrow()
 
     expect(() => enable()).toThrow(
       'Please provide the `proofSignal` first using `.update()` or `.init()` as applicable.'
@@ -155,7 +146,7 @@ describe('activation', () => {
 
 describe('remote fonts', () => {
   it('loads remote font by default', () => {
-    init('wld-container-test', { externalNullifier: VALID_ABI })
+    init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER })
 
     const elements = document.getElementsByTagName('link')
 
@@ -176,7 +167,7 @@ describe('remote fonts', () => {
   })
 
   it('does not load remote font if disabled', () => {
-    init('wld-container-test', { externalNullifier: VALID_ABI, disableRemoteFonts: true })
+    init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER, disableRemoteFonts: true })
 
     // No external stylesheet is loaded
     const elements = document.getElementsByTagName('link')
@@ -188,7 +179,7 @@ describe('state checks', () => {
   it('isInitialized', () => {
     expect(isInitialized()).toBeFalsy()
 
-    init('wld-container-test', { externalNullifier: VALID_ABI })
+    init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER })
 
     expect(isInitialized()).toBeTruthy()
   })
@@ -196,7 +187,7 @@ describe('state checks', () => {
   it('isEnabled', () => {
     expect(isEnabled()).toBeFalsy()
 
-    init('wld-container-test', { externalNullifier: VALID_ABI, proofSignal: VALID_ABI })
+    init('wld-container-test', { externalNullifier: SAMPLE_EXTERNAL_NULLIFIER, proofSignal: SAMPLE_SIGNAL })
 
     expect(isEnabled()).toBeFalsy()
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,7 +73,7 @@ describe('parameter validation', () => {
     expect(() => update({ actionId: null })).toThrow('The `actionId` parameter is always required.')
   })
 
-  it('can be initialized with empty `proofSignal`', () => {
+  it('can be initialized with empty `signal`', () => {
     expect(() => init('wld-container-test', { actionId: SAMPLE_ACTION_ID })).not.toThrow()
 
     const element = queryAllByTestId(document.body, 'world-id-box')[0]
@@ -127,7 +127,7 @@ describe('activation', () => {
     )
   })
 
-  it('cannot be activated if `proofSignal` is not present', () => {
+  it('cannot be activated if `signal` is not present', () => {
     expect(() => init('wld-container-test', { actionId: SAMPLE_ACTION_ID })).not.toThrow()
 
     expect(() => enable()).toThrow('Please provide the `signal` first using `.update()` or `.init()` as applicable.')

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,8 @@ export interface EndUserErrorDisplay {
 }
 
 export interface AppProps {
-  externalNullifier: ABIEncodedValue
-  proofSignal?: ABIEncodedValue
+  externalNullifier: string
+  proofSignal?: string
   enableTelemetry?: boolean
   appName?: string
   signalDescription?: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ export const verifyVerificationResponse = (result: Record<string, string | undef
 
 /**
  * Validates that an string looks like an ABI-encoded string. Very basic format-like check.
- * The WLD app will validate the actual value.
+ * The WLD app validates the actual values.
  * @param value string to validate
  * @returns `true` if the value looks like an ABI-encoded string; `false` otherwise
  */
@@ -74,21 +74,5 @@ export const validateInputParams = (params: AppProps): { valid: boolean; error?:
   if (!params.externalNullifier) {
     return { valid: false, error: 'The `externalNullifier` parameter is always required.' }
   }
-
-  if (!validateABILikeEncoding(params.externalNullifier)) {
-    return {
-      valid: false,
-      error:
-        'The `externalNullifier` you provided does not look valid. This parameter should be an ABI-encoded string.',
-    }
-  }
-
-  if (params.proofSignal && !validateABILikeEncoding(params.proofSignal)) {
-    return {
-      valid: false,
-      error: 'The `proofSignal` you provided does not look valid. This parameter should be an ABI-encoded string.',
-    }
-  }
-
   return { valid: true }
 }


### PR DESCRIPTION
As discussed, removing ABI-encoding requirement for input params 🎊, you'll now be able to send a simple string.