### PR TITLE
fix: margins on SDK modal

### DIFF
--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -21,3 +21,7 @@ export const H2 = styled.div`
   font-size: 1.4em;
   line-height: 1.3em;
 `
+
+export const P = styled.p`
+  margin: 1em 0;
+`

--- a/src/scenes/AwaitingConnectionScene.tsx
+++ b/src/scenes/AwaitingConnectionScene.tsx
@@ -2,7 +2,7 @@ import { IconCircleSuccess, IconHelpCircle } from 'assets/icons'
 import { Button } from 'components/Button'
 import { LinkButton } from 'components/LinkButton'
 import { QRRender } from 'components/QRRender'
-import { H1 } from 'components/text'
+import { H1, P } from 'components/text'
 import { useEffect, useState } from 'preact/hooks'
 import { useActions, useValues } from 'kea'
 import { worldLogic } from 'worldLogic'
@@ -32,6 +32,7 @@ const SColumn = styled.div`
 `
 
 const SCaption = styled.p`
+  margin: 14px 0;
   position: absolute;
   left: 32px;
   bottom: 0;
@@ -109,7 +110,7 @@ export function AwaitingConnectionScene(): JSX.Element {
     <SWrapper>
       <SColumn left>
         <H1>Prove you are a human doing this once with World ID.</H1>
-        <p>Scan this QR code with your phone's camera or the Worldcoin mobile app.</p>
+        <P>Scan this QR code with your phone's camera or the Worldcoin mobile app.</P>
         <SCaption>
           <LinkButton onClick={() => setModalView(ModalView.LearnMore)}>
             <LearnMoreLink />

--- a/src/scenes/AwaitingVerificationScene.tsx
+++ b/src/scenes/AwaitingVerificationScene.tsx
@@ -1,6 +1,6 @@
 import { Button } from 'components/Button'
 import { Loader } from 'components/Loader'
-import { H2 } from 'components/text'
+import { H2, P } from 'components/text'
 import { breakpoints } from 'const'
 import { useActions } from 'kea'
 import styled from 'styled-components'
@@ -39,7 +39,7 @@ export function AwaitingVerificationScene(): JSX.Element {
       </SLoaderWrapper>
       <SCaption>
         <H2>Confirm Request</H2>
-        <p>Please confirm the verification request in your Worldcoin app.</p>
+        <P>Please confirm the verification request in your Worldcoin app.</P>
         <Button block onClick={terminate} type="secondary">
           Cancel
         </Button>

--- a/src/scenes/CTAScene.tsx
+++ b/src/scenes/CTAScene.tsx
@@ -1,5 +1,5 @@
 import { LinkGradient } from 'components/LinkGradient'
-import { H2 } from 'components/text'
+import { H2, P } from 'components/text'
 import { breakpoints } from 'const'
 import { useValues } from 'kea'
 import styled from 'styled-components'
@@ -62,7 +62,7 @@ export function ModalCTA(): JSX.Element | null {
         <H2>Don't have the Worldcoin app?</H2>
         <SWrapper>
           <div>
-            <p>Proive unique-humanness through biometrics, privately.</p>
+            <P>Prove unique-humanness through biometrics, privately.</P>
           </div>
           <div>
             <LinkGradient href="https://worldcoin.org/app#download" target="_blank">

--- a/src/scenes/ConfirmedScene.tsx
+++ b/src/scenes/ConfirmedScene.tsx
@@ -1,6 +1,6 @@
 import { Button } from 'components/Button'
 import { StatefulIcon } from 'components/StatefulIcon'
-import { H2 } from 'components/text'
+import { H2, P } from 'components/text'
 import { breakpoints } from 'const'
 import { useActions } from 'kea'
 import styled from 'styled-components'
@@ -25,7 +25,7 @@ export function ConfirmedScene(): JSX.Element {
     <SWrapper>
       <StatefulIcon state="success" />
       <H2>Verification Confirmed!</H2>
-      <p>This World ID request has been confirmed successfully.</p>
+      <P>This World ID request has been confirmed successfully.</P>
       <Button block onClick={terminate}>
         Continue
       </Button>


### PR DESCRIPTION
## Changes

What was the problem: 
- Margins on `p` element was setted by browser defaults
- In some cases, the default styles are removed

<details>
<summary>What it looked like</summary>

![image](https://user-images.githubusercontent.com/89008845/166662951-752d485d-ec05-4bfa-95ca-76f5d4ea7f82.png)
![image](https://user-images.githubusercontent.com/89008845/166662959-b3c53abc-73a4-4925-b74c-5b7eda4f00c9.png)

| ![image](https://user-images.githubusercontent.com/89008845/166663169-50c0c626-7d2d-41b2-929d-bcad598ee435.png) | ![image](https://user-images.githubusercontent.com/89008845/166663290-45525971-649f-45da-87ba-b25d4d71a956.png) |
|:-|-:|
</details>

\
\
So, I've set margins explicitly, it should help

<details>
<summary>Result</summary>

![image](https://user-images.githubusercontent.com/89008845/166663463-0b3cb987-6d30-4e95-8907-bf0235e96800.png)
![image](https://user-images.githubusercontent.com/89008845/166663642-da13cae1-447e-43c3-93e5-e430882a6587.png)
![image](https://user-images.githubusercontent.com/89008845/166663685-9481e8f2-a179-4803-9952-82e6976fc22e.png)
![image](https://user-images.githubusercontent.com/89008845/166663815-a64a9faf-c27b-4cde-9fd9-238ba19040ab.png)
</details>
