### PR TITLE
fix: modal position

### DIFF
--- a/src/components/MainModal.tsx
+++ b/src/components/MainModal.tsx
@@ -7,7 +7,7 @@ import { createPortal } from 'preact/compat'
 import { worldLogic } from 'worldLogic'
 import { useActions, useValues } from 'kea'
 import { PrincipalScene } from 'scenes/PrincipalScene'
-import { ModalView } from 'types'
+import { CTAShownState, ModalView } from 'types'
 import { LearnMoreScene } from 'scenes/LearnMoreScene'
 import { ModalCTA } from 'scenes/CTAScene'
 import { breakpoints } from 'const'
@@ -32,11 +32,13 @@ const ModalWrapper = styled.div`
   position: fixed;
   top: 50%;
   left: 50%;
+  min-height: ${(props) => (props.ctaShownState === CTAShownState.Show ? '540px' : '360px')};
   transform: translate(-50%, -50%);
   width: 460px;
   max-width: calc(100% - 32px);
   z-index: 10000;
   display: ${(props) => (props.shown ? 'block' : 'none')};
+  transition: min-height ease-in 0.5s;
 
   @media (max-width: ${breakpoints.sm}) {
     width: 100%;
@@ -125,13 +127,13 @@ function ModalBody(): JSX.Element {
 }
 
 export function MainModal(): JSX.Element {
-  const { isAppActive } = useValues(worldLogic)
+  const { isAppActive, ctaShownState } = useValues(worldLogic)
   const { terminate } = useActions(worldLogic)
 
   return createPortal(
     <GlobalStyles>
       <Overlay onClick={terminate} shown={isAppActive} data-testId="overlay" />
-      <ModalWrapper shown={isAppActive} data-testId="modal-wrapper">
+      <ModalWrapper ctaShownState={ctaShownState} shown={isAppActive} data-testId="modal-wrapper">
         {isAppActive && (
           <>
             <ModalContent>

--- a/src/components/MainModal.tsx
+++ b/src/components/MainModal.tsx
@@ -32,13 +32,11 @@ const ModalWrapper = styled.div`
   position: fixed;
   top: 50%;
   left: 50%;
-  min-height: 540px;
   transform: translate(-50%, -50%);
   width: 460px;
   max-width: calc(100% - 32px);
   z-index: 10000;
   display: ${(props) => (props.shown ? 'block' : 'none')};
-  overflow-y: auto;
 
   @media (max-width: ${breakpoints.sm}) {
     width: 100%;

--- a/src/scenes/CTAScene.tsx
+++ b/src/scenes/CTAScene.tsx
@@ -15,7 +15,7 @@ const SWrapper = styled.div`
 `
 
 const SModalCTA = styled.div`
-  position: relative;
+  position: absolute;
   background-color: white;
   border-radius: var(--radius);
   margin-top: 32px;
@@ -26,7 +26,6 @@ const SModalCTA = styled.div`
 
   @media (max-width: ${breakpoints.sm}) {
     animation: unset !important;
-    position: absolute;
     bottom: 0;
     font-size: 0.85em;
     border-top: 1px solid var(--border-secondary);


### PR DESCRIPTION
Fixes #8 

## Changes

- Remove fixed `min-height` on `ModalWrapper`
- Remove overflow on `ModalWrapper`
- Change `SModalCTA` position to `absolute`


### Result
Main modal content is centered, CTA box below it.


https://user-images.githubusercontent.com/89008845/166670864-45e39c91-77cd-4e57-9c8e-3eb5999b1a45.mp4
