### PR TITLE
feat: handle PostHog errors gracefully

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.2",
+  "enabled": true,
+  "language": "en-US",
+  "allowCompoundWords": true,
+  "dictionaries": ["typescript", "node", "npm", "html"],
+  "enabledLanguageIds": ["typescript", "typescriptreact", "javascript", "markdown", "yaml", "json"],
+  "words": ["keccak", "merkle", "nullifer", "PostHog", "Worldcoin"]
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -4,24 +4,24 @@ import { ErrorCodes } from 'types'
 // Set at build time
 declare const worldIdJSVersion: string
 
-function factoryPosthogFetchError(error: unknown) {
-  return { name: 'posthog-error', error }
+function factoryPostHogFetchError(error: unknown) {
+  return { name: 'telemetry-error', error }
 }
 
 window.onunhandledrejection = function (event) {
-  return event.reason.name !== 'posthog-error'
+  return event.reason.name !== 'telemetry-error'
 }
 
-async function posthogFetch(input: RequestInfo, init?: RequestInit) {
+async function posthogFetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
   try {
     return await window.fetch(input, init)
   } catch (error) {
-    throw factoryPosthogFetchError(error)
+    throw factoryPostHogFetchError(error)
   }
 }
 
 const posthog = createInternalPostHogInstance(
-  'phc_QttqgDbMQDYHX1EMH7FnT6ECBVzdp0kGUq92aQaVQ6I',
+  'phc_QttqgDbMQDYHX1EMH7FnT6ECBVzdp0kGUq92aQaVQ6I', // cspell:disable-line
   { fetch: posthogFetch },
   globalThis
 )


### PR DESCRIPTION
I looked into the code of the used module and found out that it does not provide error handling logic: https://github.com/PostHog/posthog-js-lite/blob/master/src/index.ts#L121
We can only override fetch. I override the fetch so that it throws a specific error. And then I added a global handler with a check for this error to prevent it from bubbling up.

## Before
![image](https://user-images.githubusercontent.com/104859710/177145832-43b8d829-d1d0-487e-b498-02f51d54e18a.png)

## After
![image](https://user-images.githubusercontent.com/104859710/177145615-97b1a61a-0686-407d-89c5-b5d31bda7634.png)