### PR TITLE
fix: reinit connection when disconnect with error

### DIFF
--- a/id/src/logics/verificationLogic.ts
+++ b/id/src/logics/verificationLogic.ts
@@ -118,6 +118,12 @@ export const verificationLogic = kea<verificationLogicType>([
         }
       })
 
+      connector.on('disconnect', (error) => {
+        if (error) {
+          actions.initConnection()
+        }
+      })
+
       telemetryVerificationLaunched()
     },
     setConnectorUri: ({ connectorUri }) => {


### PR DESCRIPTION
@paolodamico look, this small fix does not solve our problem entirely, but it makes the widget work more stable.

After the widget has worked, we will call disconnect, can you explain why we are doing this? Maybe keep the connection always? that is, to remove this condition.

I studied `@walletconnect/client` code for a long time, it has a mechanism for restoring the connection after failures. in rare cases, it does not work and does not notify us in any way. It's still hard for me to say why and how to fix it. I'm not even sure I can reproduce this heisenbug.
