### PR TITLE
feat: add return_to to mobile QR

### DIFF
--- a/id/src/logics/verificationLogic.ts
+++ b/id/src/logics/verificationLogic.ts
@@ -126,7 +126,8 @@ export const verificationLogic = kea<verificationLogicType>([
       }
 
       const qrData = buildQRData(connector)
-      actions.setQrCodeContent(qrData)
+      const mobileQRCode = buildQRData(connector, window.location.href)
+      actions.setQrCodeContent({ default: qrData, mobile: mobileQRCode })
       actions.finishWidgetLoading()
     },
 

--- a/id/src/logics/widgetLogic.ts
+++ b/id/src/logics/widgetLogic.ts
@@ -1,6 +1,6 @@
 import { kea, actions, reducers, path, events, props, propsChanged, listeners } from 'kea'
 import { initTelemetry } from 'telemetry'
-import { AppProps, ModalView } from 'types'
+import { AppProps, ModalView, QRContentInterface } from 'types'
 import { validateInputParams } from 'utils'
 
 import type { widgetLogicType } from './widgetLogicType'
@@ -20,7 +20,7 @@ export const widgetLogic = kea<widgetLogicType>([
     toggleModal: true,
     initTelemetry: true,
     setModalView: (view: ModalView) => ({ view }),
-    setQrCodeContent: (content: string) => ({ content }),
+    setQrCodeContent: (content: QRContentInterface) => ({ content }),
     setIsDevMode: (isDev: boolean) => ({ isDev }),
   }),
   reducers({
@@ -50,7 +50,7 @@ export const widgetLogic = kea<widgetLogicType>([
     ],
 
     qrCodeContent: [
-      null as string | null,
+      null as QRContentInterface | null,
       {
         setQrCodeContent: (_, { content }) => content,
       },

--- a/id/src/scenes/AwaitingConnectionScene.tsx
+++ b/id/src/scenes/AwaitingConnectionScene.tsx
@@ -175,7 +175,7 @@ export function AwaitingConnectionScene() {
             </SMainText>
 
             <SMainCopy>
-              {media === 'desktop' && <CopyToClipboard color="neutral" size="sm" data={qrCodeContent} />}
+              {media === 'desktop' && <CopyToClipboard color="neutral" size="sm" data={qrCodeContent?.default} />}
 
               {media !== 'desktop' && !codeShown && (
                 <Button variant="link" color="default" size="xl" onClick={toggleCodeShown}>
@@ -184,7 +184,12 @@ export function AwaitingConnectionScene() {
               )}
 
               {media !== 'desktop' && codeShown && (
-                <CopyToClipboard variant="link" color="primary" size="xl" data={qrCodeContent} />
+                <CopyToClipboard
+                  variant="link"
+                  color="primary"
+                  size="xl"
+                  data={qrCodeContent?.mobile || qrCodeContent?.default}
+                />
               )}
             </SMainCopy>
 
@@ -192,7 +197,7 @@ export function AwaitingConnectionScene() {
               {media !== 'desktop' && !codeShown ? (
                 <WorldcoinApp />
               ) : qrCodeContent ? (
-                <Qrcode data={qrCodeContent} />
+                <Qrcode data={qrCodeContent.default} />
               ) : null}
             </SMainCode>
 
@@ -202,7 +207,7 @@ export function AwaitingConnectionScene() {
                 size="xl"
                 fullWidth
                 as="a"
-                href={qrCodeContent ?? 'https://worldcoin.org/verify'}
+                href={(qrCodeContent?.mobile || qrCodeContent?.default) ?? 'https://worldcoin.org/verify'}
                 target="_blank"
               >
                 Open Worldcoin app

--- a/id/src/types.ts
+++ b/id/src/types.ts
@@ -95,3 +95,8 @@ export interface HashFunctionOutput {
   hash: BigInt
   digest: string
 }
+
+export interface QRContentInterface {
+  default: string
+  mobile?: string
+}

--- a/id/src/utils.ts
+++ b/id/src/utils.ts
@@ -153,13 +153,18 @@ export function keccak256(value: BytesLike): string {
  * @param connector WalletConnect connection instance
  * @returns string
  */
-export function buildQRData(connector: WalletConnect): string {
+export function buildQRData(connector: WalletConnect, returnUrl?: string): string {
   const bridgeUrl = new URL(connector.bridge)
   const result = new URL('https://worldcoin.org/verify')
   result.searchParams.append('t', connector.handshakeTopic)
   result.searchParams.append('k', connector.key)
   result.searchParams.append('b', bridgeUrl.hostname)
   result.searchParams.append('v', '1')
+
+  if (returnUrl) {
+    // The returnUrl optionally instructs the WLD app how to return to the website after the verification is complete (intended for mobile only).
+    result.searchParams.append('r', returnUrl)
+  }
 
   return result.toString()
 }


### PR DESCRIPTION
## Changes

- Adds `r` param to deeplink (when using widget on mobile) so the user can easily return to the website they were at after doing the Worldcoin verification process.
