### PR TITLE
fix: global styles fonts

### DIFF
--- a/id/src/index.html
+++ b/id/src/index.html
@@ -4,13 +4,21 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500&family=Sora:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+
     <style>
       html,
       body {
         margin: 0;
         background-color: #ecf0f3;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans',
-          'Helvetica Neue', sans-serif;
+        font-family: 'Rubik', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+          'Open Sans', 'Helvetica Neue', sans-serif;
       }
 
       .root {
@@ -45,6 +53,8 @@
         border: 0;
         border-radius: 6px;
         padding: 10px 0;
+        font-family: 'Rubik', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+          'Open Sans', 'Helvetica Neue', sans-serif;
       }
 
       .btn:disabled {

--- a/id/src/stitches.ts
+++ b/id/src/stitches.ts
@@ -2,10 +2,6 @@ import { createStitches, createTheme, globalCss } from '@stitches/react'
 
 export const globalStyles = globalCss({
   '@import': 'https://fonts.googleapis.com/css2?family=Rubik:wght@400;500&family=Sora:wght@600&display=swap',
-
-  '*': {
-    fontFamily: '"Rubik", Arial, Helvetica, sans-serif',
-  },
 })
 
 export const { styled, css, getCssText } = createStitches({


### PR DESCRIPTION
Closes #65 & [WID-115](https://linear.app/worldcoin/issue/WID-115/dont-override-target-pages-fonts)

- Remove `font-family` property from global styles

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/89008845/192526293-869fbf8e-7005-40e9-9c7f-23f78fd589d2.png)
![image](https://user-images.githubusercontent.com/89008845/192526616-847956c6-b544-4f98-b662-d9b46451e390.png)
</details>