### PR TITLE
style: fix mobile experience in modal window

### DIFF
--- a/id/src/components/Dialog.tsx
+++ b/id/src/components/Dialog.tsx
@@ -2,6 +2,8 @@ import { styled } from 'stitches'
 
 export const Dialog = styled('div', {
   boxSizing: 'border-box',
+  minHeight: 0,
+  overflow: 'auto',
   padding: '24px',
   color: '$color',
   background: '$background',

--- a/id/src/components/Overlay.tsx
+++ b/id/src/components/Overlay.tsx
@@ -8,7 +8,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 const OverlayRoot = motion(
   styled('div', {
     width: '100%',
-    height: '100vh',
+    height: '100%',
     position: 'fixed',
     zIndex: 2147483647, // maximum possible value
     top: '0',


### PR DESCRIPTION
1. The toolbar with the address bar in chrome on android hides when scrolling. And also 100vh is the height of the entire screen, the height of the toolbar is not taken into account. Instead of 100vh we should use 100%.

2. I added scrolling inside the modal window so that its content is not cut off.
