### PR TITLE
chore: init release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,9 +1,6 @@
 name: Create release
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       bump-level:
@@ -15,7 +12,6 @@ on:
           - patch
           - minor
           - major
-
 
 jobs:
   create:


### PR DESCRIPTION
## Changes

Added workflow for automatically bump package version and publish it to npm on push to main or on manual run this workflow.
